### PR TITLE
Add: deleted_at users and posts dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $ docker compose up
 host$ docker compose exec db sh -c "mysql < /sqlscripts/000_create.sql"
 host$ docker compose exec db sh -c "mysql training < /sqlscripts/001_insert.sql"
 host$ docker compose exec db sh -c "mysql training < /sqlscripts/002_insert_more_dataset.sql"
+host$ docker compose exec db sh -c "mysql training < /sqlscripts/003_insert_deleted_at_user_and_post.sql"
 ```
 
 React を開発する人はブラウザの拡張機能をインストールしてください。(任意)

--- a/mysql/sql/003_insert_deleted_at_user_and_post.sql
+++ b/mysql/sql/003_insert_deleted_at_user_and_post.sql
@@ -1,0 +1,46 @@
+-- すでに削除済みのユーザーを5つ追加する
+INSERT INTO users (name, password, created_at, updated_at, deleted_at) VALUES 
+('deleted_user1', 'password', NOW(), NOW(), NOW()),
+('deleted_user2', 'password', NOW(), NOW(), NOW()),
+('deleted_user3', 'password', NOW(), NOW(), NOW()),
+('deleted_user4', 'password', NOW(), NOW(), NOW()),
+('deleted_user5', 'password', NOW(), NOW(), NOW());
+
+-- 削除済みのツイートを削除済みユーザーに対して2つずつ追加する
+-- 削除済みユーザー1に紐づくツイート
+INSERT INTO posts (user_id, title, body, created_at, updated_at, deleted_at) VALUES 
+((SELECT id FROM users WHERE name = 'deleted_user1'), '削除済みツイート1', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+((SELECT id FROM users WHERE name = 'deleted_user1'), '削除済みツイート2', 'このツイートは削除されました。', NOW(), NOW(), NOW());
+
+-- 削除済みユーザー2に紐づくツイート
+INSERT INTO posts (user_id, title, body, created_at, updated_at, deleted_at) VALUES 
+((SELECT id FROM users WHERE name = 'deleted_user2'), '削除済みツイート1', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+((SELECT id FROM users WHERE name = 'deleted_user2'), '削除済みツイート2', 'このツイートは削除されました。', NOW(), NOW(), NOW());
+
+-- 削除済みユーザー3に紐づくツイート
+INSERT INTO posts (user_id, title, body, created_at, updated_at, deleted_at) VALUES 
+((SELECT id FROM users WHERE name = 'deleted_user3'), '削除済みツイート1', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+((SELECT id FROM users WHERE name = 'deleted_user3'), '削除済みツイート2', 'このツイートは削除されました。', NOW(), NOW(), NOW());
+
+-- 削除済みユーザー4に紐づくツイート
+INSERT INTO posts (user_id, title, body, created_at, updated_at, deleted_at) VALUES 
+((SELECT id FROM users WHERE name = 'deleted_user4'), '削除済みツイート1', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+((SELECT id FROM users WHERE name = 'deleted_user4'), '削除済みツイート2', 'このツイートは削除されました。', NOW(), NOW(), NOW());
+
+-- 削除済みユーザー5に紐づくツイート
+INSERT INTO posts (user_id, title, body, created_at, updated_at, deleted_at) VALUES 
+((SELECT id FROM users WHERE name = 'deleted_user5'), '削除済みツイート1', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+((SELECT id FROM users WHERE name = 'deleted_user5'), '削除済みツイート2', 'このツイートは削除されました。', NOW(), NOW(), NOW());
+
+-- まだ削除していないユーザーの削除済みツイートを追加する
+-- これらのツイートのIDは自動インクリメントで設定されるため、明示的にIDを指定する必要はありません
+
+INSERT INTO posts (user_id, title, body, created_at, updated_at, deleted_at) VALUES 
+(1, '削除済みツイート', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+(2, '削除済みツイート', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+(3, '削除済みツイート', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+(4, '削除済みツイート', 'このツイートは削除されました。', NOW(), NOW(), NOW()),
+(5, '削除済みツイート', 'このツイートは削除されました。', NOW(), NOW(), NOW());
+
+-- post_idが71から80のものを削除扱いに変更し、内容も変更する
+UPDATE posts SET title = '削除済みツイート', body = 'このツイートは削除されました。', deleted_at = NOW() WHERE id BETWEEN 71 AND 80;


### PR DESCRIPTION
close #44 

# やったこと
- deleted_atがnullでないデータの追加

# 確認してほしいこと
- [ ] READMEを見ながら追加されたデータのinsertを行う
- [ ] MySQLのクライアントにdocker compose exec db mysql trainingで入り、以下のqueryを実施して問題なくデータがinsertされていることを確認する
```
-- 削除済みユーザーの確認
SELECT * FROM users WHERE deleted_at IS NOT NULL;

-- 削除済みツイートの確認（新規追加分）
SELECT * FROM posts WHERE deleted_at IS NOT NULL AND user_id IN (SELECT id FROM users WHERE name LIKE 'deleted_user%');

-- post_idが71から80のツイートの確認
SELECT * FROM posts WHERE id BETWEEN 71 AND 80 AND deleted_at IS NOT NULL;

-- 削除されていないユーザーの削除済みツイートの確認
SELECT * FROM posts WHERE deleted_at IS NOT NULL AND user_id NOT IN (SELECT id FROM users WHERE deleted_at IS NOT NULL);
```