### PR TITLE
オフセットが合計post数を超えていた場合not recordエラーを返すように修正

### DIFF
--- a/backend/internal/repositories/all_tweets_repository.go
+++ b/backend/internal/repositories/all_tweets_repository.go
@@ -6,6 +6,7 @@ import (
 	"myapp/internal/external"
 
 	"gorm.io/gorm"
+	"errors"
 )
 
 type AllTweetsRepository struct {
@@ -22,7 +23,20 @@ func NewAllTweetsRepository() *AllTweetsRepository {
 }
 
 func (r *AllTweetsRepository) GetAll(offset int, limit int) ([]*entities.Post, error) {
+
+
+	//DB内の最大ツイート数会得
+	var maxTweetNum int64
+	r.Conn.Model(&entities.Post{}).Where("deleted_at IS NULL").Count(&maxTweetNum)
+	
+	//最大ツイート数を超えるoffsetが指定された場合の処理
+	if int(maxTweetNum) < offset+1 {
+		notRecord := errors.New("not record")
+		return nil, notRecord
+	}
+
 	var tweets []*entities.Post
+	
 	// 実際のデータはobjに入る
 	// resultでDBアクセスの状況とかが見れる(エラーハンドリング)
 	// deleted_atがnullのものは、投稿が存在するので、nullのものだけ全部取得


### PR DESCRIPTION
# 概要
ページングに際してオフセットがdeleteでない合計post数を超えていた場合に空配列を返すようにしていたため、not Recordエラーを返すように修正
https://github.com/givery-bootcamp/training-app-2024/issues/4

# 確認/test
deleteでないpost数以上のオフセットが指定されていた場合、not Recordエラーを返すことを確認
<img width="761" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team4/assets/84378453/2825efcb-26a8-40b5-bdaa-5b62ad859dc4">

# レビュワーへ
- オフセットは0から始まるため、比較の際は+1しています
```go
	if int(maxTweetNum) < offset+1 {
		notRecord := errors.New("not record")
		return nil, notRecord
	}
```