### PR TITLE
投稿作成APIの実装

### DIFF
--- a/backend/internal/controllers/post_tweet_detail_controller.go
+++ b/backend/internal/controllers/post_tweet_detail_controller.go
@@ -24,7 +24,7 @@ func PostTweetDetail(ctx *gin.Context) {
 	if err != nil {
 		handleError(ctx, 500, err)
 	} else if result != nil {
-		ctx.JSON(http.StatusCreated, gin.H{"id": result.ID})
+		ctx.JSON(http.StatusCreated, gin.H{"id": result.ID, "created_at": result.CreatedAt})
 	} else {
 		handleError(ctx, 404, errors.New("not found"))
 	}

--- a/backend/internal/controllers/post_tweet_detail_controller.go
+++ b/backend/internal/controllers/post_tweet_detail_controller.go
@@ -1,0 +1,31 @@
+package controllers
+
+import (
+	"errors"
+	"myapp/internal/entities"
+	"myapp/internal/usecases"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func PostTweetDetail(ctx *gin.Context) {
+	// 指定したリクエストボディの形式にバインドする
+	requestBody := entities.CreatePostBody{}
+	if err := ctx.ShouldBindJSON(&requestBody); err != nil {
+		handleError(ctx, 400, errors.New("failed to parse request body"))
+		return
+	}
+	usecase := usecases.NewCreateTweetDetailsUsecase()
+
+	// ユースケースを実行
+	result, err := usecase.Execute(requestBody)
+
+	if err != nil {
+		handleError(ctx, 500, err)
+	} else if result != nil {
+		ctx.JSON(http.StatusCreated, gin.H{"id": result.ID})
+	} else {
+		handleError(ctx, 404, errors.New("not found"))
+	}
+}

--- a/backend/internal/entities/post.go
+++ b/backend/internal/entities/post.go
@@ -12,3 +12,10 @@ type Post struct {
 	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
 	DeletedAt *time.Time `json:"deleted_at" db:"deleted_at"`
 }
+
+// 投稿用のリクエストボディ
+type CreatePostBody struct {
+	UserID int    `json:"user_id"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+}

--- a/backend/internal/entities/post.go
+++ b/backend/internal/entities/post.go
@@ -4,18 +4,18 @@ package entities
 import "time"
 
 type Post struct {
-	ID        int        `json:"id" db:"id"`
-	UserID    int        `json:"user_id" db:"user_id"`
-	Title     string     `json:"title" db:"title"`
-	Body      string     `json:"body" db:"body"`
-	CreatedAt time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt time.Time  `json:"updated_at" db:"updated_at"`
+	ID        *int        `json:"id" db:"id"`
+	UserID    *int        `json:"user_id" db:"user_id"`
+	Title     *string     `json:"title" db:"title"`
+	Body      *string     `json:"body" db:"body"`
+	CreatedAt *time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt *time.Time  `json:"updated_at" db:"updated_at"`
 	DeletedAt *time.Time `json:"deleted_at" db:"deleted_at"`
 }
 
 // 投稿用のリクエストボディ
 type CreatePostBody struct {
-	UserID int    `json:"user_id"`
-	Title  string `json:"title"`
-	Body   string `json:"body"`
+	UserID *int    `json:"user_id"`
+	Title  *string `json:"title"`
+	Body   *string `json:"body"`
 }

--- a/backend/internal/interfaces/tweet_detail.go
+++ b/backend/internal/interfaces/tweet_detail.go
@@ -7,4 +7,5 @@ import (
 
 type TweetDetailRepository interface {
 	Get(tweetId int) (*entities.Post, error)
+	Create(body entities.CreatePostBody) (*entities.Post, error)
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -15,4 +15,5 @@ func SetupRoutes(app *gin.Engine) {
 	// AllTweets の関数を直接呼び出す
 	app.GET("/tweets", controllers.AllTweets)
 	app.GET("/tweets/:tweetId", controllers.TweetDetail) // tweetIdでツイートの詳細を取得
+	app.POST("/tweets", controllers.PostTweetDetail)     // ツイートを投稿
 }

--- a/backend/internal/repositories/tweet_detail.go
+++ b/backend/internal/repositories/tweet_detail.go
@@ -36,3 +36,21 @@ func (r *TweetDetailRepository) Get(tweetId int) (*entities.Post, error) {
 	}
 	return tweet, nil
 }
+
+func (r *TweetDetailRepository) Create(body entities.CreatePostBody) (*entities.Post, error) {
+	var tweet *entities.Post
+
+	result := r.Conn.Create(&entities.Post{
+		UserID: body.UserID,
+		Title:  body.Title,
+		Body:   body.Body,
+	}).Scan(&tweet)
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	return tweet, nil
+}

--- a/backend/internal/usecases/create_tweet_details_usecase.go
+++ b/backend/internal/usecases/create_tweet_details_usecase.go
@@ -1,0 +1,26 @@
+// usecase層はビジネスロジックを定義する
+// usecase層は基本的にrepository層にアクセスし、controller層にデータを返す
+package usecases
+
+import (
+	"myapp/internal/entities"
+	"myapp/internal/interfaces"
+	"myapp/internal/repositories"
+)
+
+type CreateTweetDetailsUsecase struct {
+	repository interfaces.TweetDetailRepository
+}
+
+// Newをつけたメソッドを定義してConstructorを生成
+func NewCreateTweetDetailsUsecase() *CreateTweetDetailsUsecase {
+	r := repositories.NewTweetDetailRepository()
+
+	return &CreateTweetDetailsUsecase{
+		repository: r,
+	}
+}
+
+func (u *CreateTweetDetailsUsecase) Execute(body entities.CreatePostBody) (*entities.Post, error) {
+	return u.repository.Create(body)
+}


### PR DESCRIPTION
### Issue番号
* #32 

### やったこと
* ツイート投稿用のリクエストボディの定義
* ツイート投稿用のdb操作, usecase, controllerを追加
* ツイート投稿用の `POST: /tweets`endpointの追加

### やらないこと
* 更新・削除機能の追加

### できるようになること（ユーザ目線）
* ツイートの新規投稿ができるようになり、永続化される

### できなくなること（ユーザ目線）
* 特になし

### 動作確認
* ローカルでのcurl実行
```
curl -X POST 'http://localhost:9000/tweets' \
--data-raw '{
  "user_id": 1,
  "title": "test",
  "body": "hohgoehoge"
}'

{"id":8}
```

### その他
* 特に無し