### PR TITLE
Homeの左下に表示されているサインインボタンを実装

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@aspida/fetch": "^1.14.0",
     "@yamada-ui/react": "^1.3.11",
     "aspida": "^1.14.0",
+    "cookies-next": "^4.2.1",
     "next": "14.2.3",
     "prettier": "^3.2.5",
     "react": "^18",

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { UserMenu } from '@/features/User/UserMenu';
-import { Button, Divider, Flex, HStack, Icon, Spacer, VStack } from '@yamada-ui/react';
+import { Button, Divider, Flex, HStack, Icon, Spacer, VStack, ui } from '@yamada-ui/react';
 import { IconType } from 'react-icons';
 import { FaHouse } from 'react-icons/fa6';
 import { FaUser } from 'react-icons/fa6';
@@ -29,8 +29,8 @@ const items: SidebarItem[] = [
 
 export default function Sidebar({ children }: SidebarProps) {
   return (
-    <Flex flexDirection="row">
-      <VStack w="300px" h="100vh" padding="md" position="sticky" top="0">
+    <Flex overflow={'hidden'}>
+      <VStack maxWidth={"280px"} w={"full"} h="100vh" display={"grid"} gridTemplateRows={"repeat(3,auto) 1fr"} padding="md">
         {items.map((item, index) => (
           <Button
             key={index}
@@ -48,10 +48,11 @@ export default function Sidebar({ children }: SidebarProps) {
         <Button fontSize="lg" p="md" rounded="40" bg="sky.400">
           ポストする
         </Button>
-        <Spacer />
-        <UserMenu />
+        <Flex justifyContent={'end'} direction={'column'}>
+          <UserMenu />
+        </Flex>
       </VStack>
-      <Divider orientation="vertical" h="100vh" position="sticky" top="0" />
+      <Divider orientation="vertical" h="100vh" />
       {children}
     </Flex>
   );

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { Button, Divider, Flex, HStack, Icon, VStack } from '@yamada-ui/react';
+import { UserMenu } from '@/features/User/UserMenu';
+import { Button, Divider, Flex, HStack, Icon, Spacer, VStack } from '@yamada-ui/react';
 import { IconType } from 'react-icons';
 import { FaHouse } from 'react-icons/fa6';
 import { FaUser } from 'react-icons/fa6';
@@ -47,6 +48,8 @@ export default function Sidebar({ children }: SidebarProps) {
         <Button fontSize="lg" p="md" rounded="40" bg="sky.400">
           ポストする
         </Button>
+        <Spacer />
+        <UserMenu />
       </VStack>
       <Divider orientation="vertical" h="100vh" position="sticky" top="0" />
       {children}

--- a/frontend/src/features/Auth/components/LogoutModal/index.tsx
+++ b/frontend/src/features/Auth/components/LogoutModal/index.tsx
@@ -1,6 +1,7 @@
 import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Flex, Image } from "@yamada-ui/react";
 import { useRouter } from "next/router";
 import { useCallback } from 'react';
+import { deleteCookie } from 'cookies-next';
 
 const LogoutModal = () => {
 
@@ -11,6 +12,7 @@ const LogoutModal = () => {
 
     const logout = useCallback(() => {
         // 1.ログアウト処理(cookieで実装)
+        deleteCookie("jwt");
 
         // 2.signInに遷移
         router.push("/signin")

--- a/frontend/src/features/Auth/components/LogoutModal/index.tsx
+++ b/frontend/src/features/Auth/components/LogoutModal/index.tsx
@@ -19,11 +19,6 @@ const LogoutModal = () => {
     return (
       <div>
         <Modal isOpen={true}>
-        <Image
-            src="https://not-found.com/not-found.png"
-            fallback="https://via.placeholder.com/512"
-            size="px"
-        />
         <ModalHeader display={"flex"} justifyContent={"center"}>Xからログアウトしますか</ModalHeader>
             <ModalBody>
             いつでもログインし直すことができます。アカウントを切り替える場合は、既存のアカウントを追加すると切り替えることができます。

--- a/frontend/src/features/Auth/components/LogoutModal/index.tsx
+++ b/frontend/src/features/Auth/components/LogoutModal/index.tsx
@@ -20,16 +20,16 @@ const LogoutModal = () => {
       <div>
         <Modal isOpen={true}>
         <ModalHeader display={"flex"} justifyContent={"center"}>Xからログアウトしますか</ModalHeader>
-            <ModalBody>
+            <ModalBody fontSize={"sm"}>
             いつでもログインし直すことができます。アカウントを切り替える場合は、既存のアカウントを追加すると切り替えることができます。
             </ModalBody>
 
             <ModalFooter justifyContent={"center"}>
-                <Flex direction={"column"}>
-                    <Button variant="ghost" onClick={logout}>
+                <Flex direction={"column"} gap={"sm"}>
+                    <Button colorScheme="primary" onClick={logout} isRounded={true} px={16} py={2} fontSize={"sm"}>
                     ログアウト
                     </Button>
-                    <Button colorScheme="primary" onClick={handleCancel}>キャンセル</Button>
+                    <Button variant="outline" onClick={handleCancel} isRounded={true} px={16} py={2} fontSize={"sm"}>キャンセル</Button>
                 </Flex>
             </ModalFooter>
         </Modal>

--- a/frontend/src/features/Auth/components/LogoutModal/index.tsx
+++ b/frontend/src/features/Auth/components/LogoutModal/index.tsx
@@ -1,0 +1,45 @@
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, Flex, Image } from "@yamada-ui/react";
+import { useRouter } from "next/router";
+import { useCallback } from 'react';
+
+const LogoutModal = () => {
+
+    const router = useRouter()
+    const handleCancel = useCallback(() => {
+        router.back()
+    }, [router])
+
+    const logout = useCallback(() => {
+        // 1.ログアウト処理(cookieで実装)
+
+        // 2.signInに遷移
+        router.push("/signin")
+    }, [])
+
+    return (
+      <div>
+        <Modal isOpen={true}>
+        <Image
+            src="https://not-found.com/not-found.png"
+            fallback="https://via.placeholder.com/512"
+            size="px"
+        />
+        <ModalHeader display={"flex"} justifyContent={"center"}>Xからログアウトしますか</ModalHeader>
+            <ModalBody>
+            いつでもログインし直すことができます。アカウントを切り替える場合は、既存のアカウントを追加すると切り替えることができます。
+            </ModalBody>
+
+            <ModalFooter justifyContent={"center"}>
+                <Flex direction={"column"}>
+                    <Button variant="ghost" onClick={logout}>
+                    ログアウト
+                    </Button>
+                    <Button colorScheme="primary" onClick={handleCancel}>キャンセル</Button>
+                </Flex>
+            </ModalFooter>
+        </Modal>
+      </div>
+    );
+  };
+
+export default LogoutModal;

--- a/frontend/src/features/Home/components/Home/index.tsx
+++ b/frontend/src/features/Home/components/Home/index.tsx
@@ -8,7 +8,7 @@ export const Home: React.FC = () => {
   const posts = decodePostResponses(data || [])
 
   return (
-    <VStack direction="column" divider={<Divider />} display={"inline-block"}>
+    <VStack direction="column" divider={<Divider />} display={"inline-block"} overflowY="scroll" height={"100vh"}>
       {posts.map((post) => (
         <PostCard key={post.id} post={post} onClick={() => {
           handleOnTapPost(post.id.toString())

--- a/frontend/src/features/User/UserMenu.tsx
+++ b/frontend/src/features/User/UserMenu.tsx
@@ -19,20 +19,22 @@ export const UserMenu: React.FC = () => {
 
   return (
     <Popover placement="top">
-    <PopoverTrigger>
-    <HStack ref={ref} cursor={"pointer"} onClick={handleClick} bg={hovered ? "gray.100" : "transparent" } rounded="32px" p={2} >
-            <Avatar size="md" name="Hirotomo Yamada" />
-            <Flex direction={"column"}>
-                <Text whiteSpace={"nowrap"}>ユーザー名</Text>
-                <Text whiteSpace={"nowrap"}>@user-12345</Text>
-            </Flex>
-            <BsThreeDots />
-        </HStack>
-    </PopoverTrigger>
+      <PopoverTrigger>
+          <Button lineHeight={"1.3"}>
+            <HStack ref={ref} cursor={"pointer"} bg={hovered ? "gray.100" : "transparent" } rounded="32px" p={2} >
+                <Avatar size="sm" name="Hirotomo Yamada" />
+                <Flex direction={"column"}>
+                    <Text whiteSpace={"nowrap"}>ユーザー名</Text>
+                    <Text whiteSpace={"nowrap"} fontWeight={'normal'}>@user-12345</Text>
+                </Flex>
+                <BsThreeDots />
+            </HStack>
+          </Button>
+      </PopoverTrigger>
 
-    <PopoverContent>
-      <Button onClick={logout}>@user-12345からログアウト</Button>
-    </PopoverContent>
+      <PopoverContent>
+        <Button onClick={logout}>@user-12345からログアウト</Button>
+      </PopoverContent>
   </Popover>
   );
 };

--- a/frontend/src/features/User/UserMenu.tsx
+++ b/frontend/src/features/User/UserMenu.tsx
@@ -18,15 +18,13 @@ export const UserMenu: React.FC = () => {
   return (
     <Popover placement="top">
       <PopoverTrigger>
-          <Button lineHeight={"1.3"} bg={"white"} _hover={{ backgroundColor: "gray.100" }}>
-            <HStack cursor={"pointer"} rounded="32px" p={2} >
+          <Button display={"grid"} gridTemplateColumns={"auto 1fr auto"} variant="unstyled" _hover={{ backgroundColor: "gray.100" }} height={"max-content"} padding={2}>
                 <Avatar size="sm" name="Hirotomo Yamada" />
                 <Flex direction={"column"}>
                     <Text whiteSpace={"nowrap"}>ユーザー名</Text>
                     <Text whiteSpace={"nowrap"} fontWeight={'normal'}>@user-12345</Text>
                 </Flex>
                 <BsThreeDots />
-            </HStack>
           </Button>
       </PopoverTrigger>
 

--- a/frontend/src/features/User/UserMenu.tsx
+++ b/frontend/src/features/User/UserMenu.tsx
@@ -14,14 +14,12 @@ export const UserMenu: React.FC = () => {
   const logout = useCallback(() => {
     router.push('/logout');
   }, [router])
-  
-  const { hovered, ref } = useHover()
 
   return (
     <Popover placement="top">
       <PopoverTrigger>
-          <Button lineHeight={"1.3"}>
-            <HStack ref={ref} cursor={"pointer"} bg={hovered ? "gray.100" : "transparent" } rounded="32px" p={2} >
+          <Button lineHeight={"1.3"} bg={"white"} _hover={{ backgroundColor: "gray.100" }}>
+            <HStack cursor={"pointer"} rounded="32px" p={2} >
                 <Avatar size="sm" name="Hirotomo Yamada" />
                 <Flex direction={"column"}>
                     <Text whiteSpace={"nowrap"}>ユーザー名</Text>

--- a/frontend/src/features/User/UserMenu.tsx
+++ b/frontend/src/features/User/UserMenu.tsx
@@ -20,7 +20,7 @@ export const UserMenu: React.FC = () => {
   return (
     <Popover placement="top">
     <PopoverTrigger>
-    <HStack ref={ref} cursor={"pointer"} onClick={handleClick} bg={hovered ? "blue.200" : "transparent"} >
+    <HStack ref={ref} cursor={"pointer"} onClick={handleClick} bg={hovered ? "gray.100" : "transparent" } rounded="32px" p={2} >
             <Avatar size="md" name="Hirotomo Yamada" />
             <Flex direction={"column"}>
                 <Text whiteSpace={"nowrap"}>ユーザー名</Text>

--- a/frontend/src/features/User/UserMenu.tsx
+++ b/frontend/src/features/User/UserMenu.tsx
@@ -1,0 +1,38 @@
+import { ChangeEvent, useCallback } from 'react';
+import  { Avatar, Button, HStack, VStack, Text, Flex, useHover, Tooltip, Popover, PopoverTrigger, PopoverContent, PopoverHeader, PopoverBody } from "@yamada-ui/react"
+import { BsThreeDots } from "react-icons/bs";
+import { useRouter } from "next/router";
+
+export const UserMenu: React.FC = () => {
+  const router = useRouter()
+
+  const handleClick = useCallback(() => {
+    // ここにクリックされたときの処理を記述します
+    console.log("HStack clicked"); 
+  }, []);
+
+  const logout = useCallback(() => {
+    router.push('/logout');
+  }, [router])
+  
+  const { hovered, ref } = useHover()
+
+  return (
+    <Popover placement="top">
+    <PopoverTrigger>
+    <HStack ref={ref} cursor={"pointer"} onClick={handleClick} bg={hovered ? "blue.200" : "transparent"} >
+            <Avatar size="md" name="Hirotomo Yamada" />
+            <Flex direction={"column"}>
+                <Text whiteSpace={"nowrap"}>ユーザー名</Text>
+                <Text whiteSpace={"nowrap"}>@user-12345</Text>
+            </Flex>
+            <BsThreeDots />
+        </HStack>
+    </PopoverTrigger>
+
+    <PopoverContent>
+      <Button onClick={logout}>@user-12345からログアウト</Button>
+    </PopoverContent>
+  </Popover>
+  );
+};

--- a/frontend/src/pages/logout/index.tsx
+++ b/frontend/src/pages/logout/index.tsx
@@ -1,0 +1,11 @@
+import LogoutModal from "@/features/Auth/components/LogoutModal";
+
+const Page: React.FC = () => {
+  return (
+    <main>
+        <LogoutModal />
+    </main>
+  )
+};
+
+export default Page;


### PR DESCRIPTION
### Issue番号
* #53 

### やったこと
* このプルリクで何をしたのか？
- UserMenuのUI
- LoginModalのUI
- サイドバーにUserMenuを配置

### やらないこと
* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
- ユーザー名・IDを動的に反映(現在はハードコーディング)
- LoginModalのログアウト処理

### できるようになること（ユーザ目線）
* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
* 無し

### できなくなること（ユーザ目線）
* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
- 無し

### 動作確認
- [ ] UserMenuをクリックしてLoginModalが開かれるか
- [ ] LoginModalのキャンセルボタンを押してモーダルが閉じるか
- [ ] LoginModalのログインを押して、signin画面に遷移するか

https://github.com/givery-bootcamp/dena-2024-team4/assets/56498440/ac058b50-489f-478e-9c26-a5e7ddc7badb
